### PR TITLE
feat: GH action to publish

### DIFF
--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -1,0 +1,78 @@
+name: Build and Publish Docker Images
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+  release:
+    types: [published]
+
+env:
+  REGISTRY: ghcr.io
+  GAS_STATION_IMAGE_NAME: ${{ github.repository }}/gas-station
+  STREAMR_DEST_IMAGE_NAME: ${{ github.repository }}/streamr-destination
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Gas Station
+        id: meta-gas
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.GAS_STATION_IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha
+
+      - name: Extract metadata (tags, labels) for Streamr Destination
+        id: meta-streamr
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.STREAMR_DEST_IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha
+
+      - name: Build and push Gas Station image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          build-args: |
+            path=sources/gas-station
+          push: true
+          tags: ${{ steps.meta-gas.outputs.tags }}
+          labels: ${{ steps.meta-gas.outputs.labels }}
+
+      - name: Build and push Streamr Destination image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          build-args: |
+            path=destinations/streamr
+          push: true
+          tags: ${{ steps.meta-streamr.outputs.tags }}
+          labels: ${{ steps.meta-streamr.outputs.labels }} 

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ acceptance_tests_logs
 **/jenkins/data/.java
 **/jenkins/data/.lastStarted
 **/jenkins/data/*.log
+
+/gitignore


### PR DESCRIPTION
Configure CI/CD pipeline to automatically build and publish Docker images for gas-station and streamr-destination components to GitHub Container Registry on push, tag, or release events