### PR TITLE
feat: docker build caches and streamr bump

### DIFF
--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -26,6 +26,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          platforms: linux/amd64
+
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:
@@ -61,16 +66,20 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          build-args: path=sources/gas-station
           push: true
+          build-args: path=sources/gas-station
           tags: ${{ steps.meta-gas.outputs.tags }}
           labels: ${{ steps.meta-gas.outputs.labels }}
+          cache-from: type=gha,scope=gas-station
+          cache-to: type=gha,mode=max,scope=gas-station
 
       - name: Build and push Streamr Destination image
         uses: docker/build-push-action@v5
         with:
           context: .
-          build-args: path=destinations/streamr-destination
           push: true
+          build-args: path=destinations/streamr-destination
           tags: ${{ steps.meta-streamr.outputs.tags }}
-          labels: ${{ steps.meta-streamr.outputs.labels }} 
+          labels: ${{ steps.meta-streamr.outputs.labels }}
+          cache-from: type=gha,scope=streamr-destination
+          cache-to: type=gha,mode=max,scope=streamr-destination 

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -12,8 +12,8 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  GAS_STATION_IMAGE_NAME: ${{ github.repository }}/gas-station
-  STREAMR_DEST_IMAGE_NAME: ${{ github.repository }}/streamr-destination
+  GAS_STATION_IMAGE_NAME: ${{ github.repository }}/airbyte-gas-station
+  STREAMR_DEST_IMAGE_NAME: ${{ github.repository }}/airbyte-streamr-destination
 
 jobs:
   build-and-push:

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -61,8 +61,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          build-args: |
-            path=sources/gas-station
+          build-args: path=sources/gas-station
           push: true
           tags: ${{ steps.meta-gas.outputs.tags }}
           labels: ${{ steps.meta-gas.outputs.labels }}
@@ -71,8 +70,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          build-args: |
-            path=destinations/streamr
+          build-args: path=destinations/streamr-destination
           push: true
           tags: ${{ steps.meta-streamr.outputs.tags }}
           labels: ${{ steps.meta-streamr.outputs.labels }} 

--- a/destinations/streamr-destination/package.json
+++ b/destinations/streamr-destination/package.json
@@ -23,7 +23,7 @@
   },
   "main": "./lib.js",
   "dependencies": {
-    "@streamr/sdk": "^100.1.2",
+    "@streamr/sdk": "^101.1.2",
     "commander": "^11.1.0",
     "faros-feeds-sdk": "^0.9.0",
     "git-url-parse": "^11.6.0",


### PR DESCRIPTION
## Description
- gh action to publish images with cache (includes https://github.com/usherlabs/verifiable-data-streams/pull/2 which was already included as part of testing)
- push major updates on streamr


## Tests?

- already pushed to production, and it's working